### PR TITLE
[TECHNICAL_SUPPORT] LPS-47199 Only Administrators can view draft web content 

### DIFF
--- a/portal-web/docroot/html/portlet/journal/view_entries.jsp
+++ b/portal-web/docroot/html/portlet/journal/view_entries.jsp
@@ -112,11 +112,7 @@ if (displayTerms.isNavigationRecent()) {
 	articleSearchContainer.setOrderByType(orderByType);
 }
 
-int status = WorkflowConstants.STATUS_APPROVED;
-
-if (permissionChecker.isContentReviewer(user.getCompanyId(), scopeGroupId)) {
-	status = WorkflowConstants.STATUS_ANY;
-}
+int status = WorkflowConstants.STATUS_ANY;
 
 List resultsList = null;
 int totalVar = 0;
@@ -130,8 +126,6 @@ int totalVar = 0;
 
 		if (displayTerms.getNavigation().equals("mine")) {
 			userId = themeDisplay.getUserId();
-
-			status = WorkflowConstants.STATUS_ANY;
 		}
 
 		totalVar = JournalArticleServiceUtil.getGroupArticlesCount(scopeGroupId, userId, folderId, status);


### PR DESCRIPTION
Hi,

Here's my solution suggestion for the LPS-47199.

Currently, when accessing the Web Content portlet in the Control Panel, only an admin (group or portal admin, or content reviewer) can see all the contents. Other users can only see the latest approved version.

This logic was introduced with the following LPS:
LPS-36379 Regular user should not see draft articles in recent view @ f081150bb256202eab8fc35fdc309bbe6c429b51

My reasoning to use the solution in this pull request is the following:
1. The users have permission to see the draft contents, they just can't see it. However, searching for the documents reveals them.
2. Regular users don't usually have permissions to access the portlet. Only on their personal site, and they can't see the drafts even there.
3. Currently only those have permissions to see the contents who have permission to edit everything. I believe it is the valid scenario that in a live portal there are users who's job is to maintain only the web contents, or only the blogs, etc., with their own specific custom Role. These kind of Web Content editors also couldn't see all the relevant Web Contents, only by searching them. This way they can lose valuable information. 
4. The draft elements can bee seen for example in case of Blogs and Wikis.

Thanks in advance,
Laci